### PR TITLE
Fix long history warning bug caused by incorrect handling of the ref param

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# PyCharm
+.idea/

--- a/phq/kafka/payload.py
+++ b/phq/kafka/payload.py
@@ -74,13 +74,13 @@ def unpack_kafka_payload(payload):
     return item, ref
 
 
-def pack_kafka_payload(svc, item, ref):
+def pack_kafka_payload(svc, item, refs):
     payload = {
         'item': item,
         'hist': {
             'svc': svc,
             'dt': rfc3339.datetimetostr(rfc3339.now()),
-            'refs': [ref] if ref else []
+            'refs': refs or []
         }
     }
     return json.dumps(payload)

--- a/phq/kafka/payload.py
+++ b/phq/kafka/payload.py
@@ -6,7 +6,7 @@ import rfc3339
 
 log = logging.getLogger(__name__)
 
-Message = namedtuple('Message', ['id', 'payload', 'refs'])
+Message = namedtuple('Message', ['id', 'payload', 'ref'])
 
 
 def _long_hist(hist, depth=0, max_depth=100):
@@ -74,13 +74,13 @@ def unpack_kafka_payload(payload):
     return item, ref
 
 
-def pack_kafka_payload(svc, item, refs):
+def pack_kafka_payload(svc, item, ref):
     payload = {
         'item': item,
         'hist': {
             'svc': svc,
             'dt': rfc3339.datetimetostr(rfc3339.now()),
-            'refs': refs or []
+            'refs': [ref] if ref else []
         }
     }
     return json.dumps(payload)

--- a/phq/kafka/producer.py
+++ b/phq/kafka/producer.py
@@ -70,8 +70,8 @@ class Producer:
             raise ValueError(f'Invalid Kafka output topic name: {output_topic}')
 
         batch = [
-            {'key': _id, 'value': self._svc_pack_kafka_payload(payload, refs)}
-            for _id, payload, refs in messages
+            {'key': _id, 'value': self._svc_pack_kafka_payload(payload, ref)}
+            for _id, payload, ref in messages
         ]
         produce_batch(self._producer, output_topic, batch)
 
@@ -79,6 +79,6 @@ class Producer:
         if not output_topic:
             raise ValueError(f'Invalid Kafka output topic name: {output_topic}')
 
-        _id, payload, refs = message
-        packed_payload = self._svc_pack_kafka_payload(payload, refs)
+        _id, payload, ref = message
+        packed_payload = self._svc_pack_kafka_payload(payload, ref)
         produce(self._producer, output_topic, key=_id, value=packed_payload)


### PR DESCRIPTION
This is the fix for the "Message has a very long history" warning messages that we observed on the event-umbrella service after integrating with version 0.1.6 of phq-kafka-python.

There was some confusion on how the Message.ref parameter is being used and what it contains so I will try to explain:

A Message has one `ref` which is a dict as defined in 
```
def get_kafka_ref(message, hist=None):
    return {
        'topic': message.topic,
        'partition': message.partition,
        'offset': message.offset,
        'key': message.key,
        'hist': hist,
    }
```

However in the `hist` entry there are `refs` entries and each `ref` in `refs` has a `hist` entry and so on recursively.

The reason behind the failure was that the `_long_hist` function was evaluating Message.refs as a dict and always returning `True` and truncating the `hist` entry hence the warning. 

The fix is to make sure when packing the Message we wrap the `ref` dict in a list.